### PR TITLE
fix: loading saves

### DIFF
--- a/ChapterMaster.yyp
+++ b/ChapterMaster.yyp
@@ -579,7 +579,7 @@
   "isEcma":false,
   "LibraryEmitters":[],
   "MetaData":{
-    "IDEVersion":"2024.1400.0.901",
+    "IDEVersion":"2024.1400.0.904",
   },
   "name":"ChapterMaster",
   "resources":[

--- a/datafiles/main/version.json
+++ b/datafiles/main/version.json
@@ -1,5 +1,5 @@
 {
-    "build_date": "2025-12-23",
-    "version": "v0.11.05.03",
+    "build_date": "2026-01-02",
+    "version": "v0.11.05.04",
     "commit_hash": "unknown hash"
 }

--- a/objects/obj_controller/Create_0.gml
+++ b/objects/obj_controller/Create_0.gml
@@ -556,37 +556,6 @@ production_research = {
 	hvyarmcon : [0,{}],
 	dread : [0,{}],
 }
-		if (scr_has_disadv("Tech Regression: Late Conventional")) {
-			with(production_research) {
-			plastics = [0,{}];
-			mechnchem = [0,{}];
-			bolt = [0,{}];
-			power_fields = [0,{}];
-			}
-		}
-		if (scr_has_disadv("Tech Regression: Medieval")) {
-			with(production_research) {
-			metallurgy = [1,{}];
-			combustion = [0,{}];
-			plastics = [0,{}];
-			mechnchem = [0,{}];
-			bolt = [0,{}];
-			power_fields = [0,{}];
-			}
-		}
-		if (scr_has_disadv("Tech Regression: Stone Age")) {
-			with(production_research) {
-			metallurgy = [0,{}];
-			mechanisms = [0,{}];
-			chemistry = [0,{}];
-			combustion = [0,{}];
-			plastics = [0,{}];
-			mechnchem = [0,{}];
-			bolt = [0,{}];
-			psi = [0,{}];
-			power_fields = [0,{}];
-			}
-		}
 
 production_research_pathways ={
 	// 
@@ -1410,6 +1379,38 @@ command=0;
 command=obj_ini.commands;
 // Removes the command marines from marine count
 if (global.load==-1) then marines-=command;
+// Add Tech Regression stuff
+		if (scr_has_disadv("Tech Regression: Late Conventional")) {
+			with(production_research) {
+			plastics = [0,{}];
+			mechnchem = [0,{}];
+			bolt = [0,{}];
+			power_fields = [0,{}];
+			}
+		}
+		if (scr_has_disadv("Tech Regression: Medieval")) {
+			with(production_research) {
+			metallurgy = [1,{}];
+			combustion = [0,{}];
+			plastics = [0,{}];
+			mechnchem = [0,{}];
+			bolt = [0,{}];
+			power_fields = [0,{}];
+			}
+		}
+		if (scr_has_disadv("Tech Regression: Stone Age")) {
+			with(production_research) {
+			metallurgy = [0,{}];
+			mechanisms = [0,{}];
+			chemistry = [0,{}];
+			combustion = [0,{}];
+			plastics = [0,{}];
+			mechnchem = [0,{}];
+			bolt = [0,{}];
+			psi = [0,{}];
+			power_fields = [0,{}];
+			}
+		}
 // **** INTRO SCREEN ****
 temp[30]=string(check_number)+" "+string(year_fraction)+" "+string(year)+".M"+string(millenium);// Date
 temp[31]=string_upper(adept_name);// Adept name


### PR DESCRIPTION
## Purpose and Description
- "v0.11.05.04" is the new version. Should be compatible with saves from v0.11.05.03;
- Fixes crash to desktop upon trying to load a saved game.

## Testing done
- Compiled in Gamemaker;
- Loaded a save from main menu, from previous version successfully;
- Saved a game successfully;
- Loaded said saved game both from main menu and in game.

## Related things and/or additional context
- Based on my limited understanding, crash to desktop occurred due to checking for the 3 disadvantages, before details about player's faction are loaded. And since the player's faction's details are not loaded, there were no bug reports.