### PR TITLE
fix: tomb world crash

### DIFF
--- a/datafiles/main/version.json
+++ b/datafiles/main/version.json
@@ -1,5 +1,5 @@
 {
-    "build_date": "2026-01-16",
-    "version": "v0.11.05.05",
+    "build_date": "2026-01-23",
+    "version": "v0.11.05.06",
     "commit_hash": "unknown hash"
 }

--- a/objects/obj_ncombat/Alarm_5.gml
+++ b/objects/obj_ncombat/Alarm_5.gml
@@ -13,7 +13,7 @@ if (turn_count >= 50){
     part1 = "Your forces make a fighting retreat \n"
 }
 
-var p_data = new PlanetData(battle_id, battle_object);
+p_data = new PlanetData(battle_id, battle_object);
 // check for wounded marines here to finish off, if defeated defending
 var roles = obj_ini.role[100];
 var ground_mission = (instance_exists(obj_ground_mission));

--- a/objects/obj_ncombat/Alarm_5.gml
+++ b/objects/obj_ncombat/Alarm_5.gml
@@ -13,7 +13,7 @@ if (turn_count >= 50){
     part1 = "Your forces make a fighting retreat \n"
 }
 
-p_data = new PlanetData(battle_id, battle_object);
+var p_data = new PlanetData(battle_id, battle_object);
 // check for wounded marines here to finish off, if defeated defending
 var roles = obj_ini.role[100];
 var ground_mission = (instance_exists(obj_ground_mission));

--- a/objects/obj_star/Alarm_0.gml
+++ b/objects/obj_star/Alarm_0.gml
@@ -119,7 +119,7 @@ switch (star) {
         for (rui = 1; rui <= 4; rui++) {
             if (planets >= rui) {
                 planet[rui] = 1;
-                p_type[rui] = choose("Temperate", "Temperate", choose("Temperate", "Shrine"), "Feudal", "Agri", "Death", "Desert", "Ice", "Hive");
+                p_type[rui] = choose("Temperate", "Temperate", choose("Temperate", "Shrine"), "Feudal", "Agri", "Death", "Desert", "Lava", "Hive");
                 if (p_type[rui] == "Agri" || p_type[rui] == "Hive") {
                     p_owner[rui] = 2;
                     p_first[rui] = 2;
@@ -180,7 +180,7 @@ switch (name) {
         planets = 3;
         p_type[1] = "Feudal";
         planet[1] = 1;
-        array_push(p_feature[1], new NewPlanetFeature(P_features.Necron_Tomb));
+    //    array_push(p_feature[1], new NewPlanetFeature(P_features.Necron_Tomb));
         p_type[2] = "Dead";
         planet[2] = 1;
         p_type[3] = "Dead";

--- a/objects/obj_star/Alarm_1.gml
+++ b/objects/obj_star/Alarm_1.gml
@@ -374,9 +374,10 @@ if (i==1) and (planets>0){
                         case "Vulvis Major":
                             ranb = 1;
                             break;
-                        case "Necron Assrape":
+					// TODO - change the name to something less crude
+                    /*    case "Necron Assrape":
                             ranb = 2;
-                            break;
+                            break; */
                         case "Morrowynd":
                             ranb = 5;
                             break;
@@ -393,7 +394,7 @@ if (i==1) and (planets>0){
                                 break;
                             case 2:
                                 if (p_type[i]!="Hive") and (p_type[i]!="Lava") and (goo==0){
-                                    array_push(p_feature[i], new NewPlanetFeature(P_features.Necron_Tomb))
+                            //        array_push(p_feature[i], new NewPlanetFeature(P_features.Necron_Tomb))
                                     goo=1;
                                 }
                                 break;
@@ -414,7 +415,7 @@ if (i==1) and (planets>0){
                             //alternative spawn for necron tomb probably needs merging with other method
                             case 6:
                                 if ((p_type[i]=="Ice") or (p_type[i]=="Dead")){
-                                    array_push(p_feature[i], new NewPlanetFeature( P_features.Necron_Tomb))
+                            //        array_push(p_feature[i], new NewPlanetFeature( P_features.Necron_Tomb))
                                     goo=1;
                                 }
                                 break;

--- a/scripts/scr_draw_planet_features/scr_draw_planet_features.gml
+++ b/scripts/scr_draw_planet_features/scr_draw_planet_features.gml
@@ -115,13 +115,13 @@ function FeatureSelected(Feature, system, planet) constructor{
 				generic=true;
 				if (feature.awake==0 && feature.sealed==0){
 					title = "Dormant Necron Tomb";
-					body = "Scans indicate a Necron Tomb lies hidden under the surface of the planet, all signs indicate the tombis dormant as we must hope it remains";
+					body = "There appears to be a Necron Tomb under the surface of the planet, hopefully it will remain inactive. In the event of it's awakening, we'd have to use a plasma bomb to seal it.";
 				} else if (feature.sealed){
 					title = "Sealed Necron Tomb";
-					body = "Exterminatus and standard imperial armaments are no proof against the Necron Scourge with any luck those sealed within this tomb will remain there";
+					body = "The Necron Tomb beneath the surface has been sealed by a plasma bomb detonation. This should prevent Necrons from causing trouble for us for some time.";
 				} else if (feature.awake){
 					title = "Awake Tomb";
-					body = "The Cursed ranks of living metal spew forth from the Necron tomb below"
+					body = "Signs of Necron activity are obvious. We need to use a plasma bomb in battle to seal them inside."
 				}
 				break;
 			case P_features.Artifact:
@@ -145,13 +145,13 @@ function FeatureSelected(Feature, system, planet) constructor{
 				title = $"Cult of {feature.name}";
 				var control_string = "";
 				if (cult_control<25){
-					control_string = "currently has limited influence on the planet but is fast gaining speed";
+					control_string = "currently has limited influence on the planet, but continues to attract new followers";
 				} else if (cult_control<50){
-					control_string = "Is rapidly gaining momentum with the planets populace and will soon sieze control of the planet if left unchecked";
+					control_string = "Has notable influence over the planets populace and is likely to interfere with imperial control of the planet in forseeable future";
 				}else if (cult_control<75){
-					control_string = "Has managed to galvanise the populace to overcome the former governor of the planet turning much of the local pdf to it's cause, it must be stopped, lest it spread.";
+					control_string = "Holds a dominant position in political control of the planet, planet's imperial allegiance hangs by a thread.";
 				} else {
-					control_string = "The cult’s rot and control of the planet is complete; even if the cult can be dismantled, the corruption is great and the population will need significant purging and monitoring to remove the taint";
+					control_string = "It effectively controls the planet. It likely will require extensive purge to bring it back to imperial control.";
 				}
 				body = $"The Cult of {feature.name} {control_string}";
 				break;				
@@ -182,9 +182,9 @@ function FeatureSelected(Feature, system, planet) constructor{
 				title = "Ork Stronghold";
 				generic = true;
 				if (planet_data.planet_forces[eFACTION.Ork]){
-					body = $"For as long as this Stronghold stands the orks here will continue to fortify it. The larger it gets the greater the capacity of this planet to produce orkish machines of war and ships and the better protected the ork forces will be from bombardment";
+					body = $"Orks have established a stronghold on this planet. In addition to protection from bombardment, they are likely more capable to build their voidships here.";
 				} else {
-					body = "Without a force of orks to hold it together the fortress is slowly pulled apart from within by the inhabitants, It's capabilities will constantly decrease until soon there will be nothing left";
+					body = "The stronghold is currently being pulled apart by the inhabitants. Ensure that orks don't return, and it should soon cease to exist.";
 				}
 				break
             case P_features.Recruiting_World:

--- a/scripts/scr_inquisition_mission/scr_inquisition_mission.gml
+++ b/scripts/scr_inquisition_mission/scr_inquisition_mission.gml
@@ -44,7 +44,7 @@ function scr_inquisition_mission(event, forced_mission = -1){
         var found_tyranid_org = false;
         var found_demon_world = false;
         
-        var necron_tomb_worlds = [];
+    //    var necron_tomb_worlds = [];
         var tyranid_org_worlds = [];
         var demon_worlds = [];
 
@@ -52,10 +52,10 @@ function scr_inquisition_mission(event, forced_mission = -1){
         for(var s = 0, _len =  array_length(all_stars); s <_len; s++){
             var _star = all_stars[s];
 
-            if (scr_star_has_planet_with_feature(_star, P_features.Necron_Tomb) && !awake_necron_star(_star.id)){
-                array_push(necron_tomb_worlds, _star);
-                found_sleeping_necrons = true;
-            }
+        //    if (scr_star_has_planet_with_feature(_star, P_features.Necron_Tomb) && !awake_necron_star(_star.id)){
+        //        array_push(necron_tomb_worlds, _star);
+        //        found_sleeping_necrons = true;
+        //    }
 
             if (star_has_planet_with_forces(_star, "Demons", 1)){
                 // array_push(demon_worlds, _star); // turning this off til i have a way to finish the mission
@@ -68,12 +68,12 @@ function scr_inquisition_mission(event, forced_mission = -1){
             }
         }
 
-        if (found_sleeping_necrons){
-            array_push(inquisition_missions, INQUISITION_MISSION.tomb_world);
-            log_message($"Was able to find a _star with dormant necron tomb for inquisition mission");
-        } else {
-            log_message($"Couldn't find any planets with a dormant necron tomb for inquisition mission")
-        }
+    //    if (found_sleeping_necrons){
+    //        array_push(inquisition_missions, INQUISITION_MISSION.tomb_world);
+    //        log_message($"Was able to find a _star with dormant necron tomb for inquisition mission");
+    //    } else {
+    //        log_message($"Couldn't find any planets with a dormant necron tomb for inquisition mission")
+    //    }
         if (found_tyranid_org){
             log_message($"Was able to find a _star with lvl 4 tyranids for inquisition mission");
             array_push(inquisition_missions, INQUISITION_MISSION.tyranid_organism);
@@ -113,7 +113,7 @@ function scr_inquisition_mission(event, forced_mission = -1){
             case INQUISITION_MISSION.inquisitor: mission_inquistion_hunt_inquisitor(); break;
             case INQUISITION_MISSION.spyrer: mission_inquistion_spyrer(); break;
             case INQUISITION_MISSION.artifact: mission_inquisition_artifact(); break;
-            case INQUISITION_MISSION.tomb_world: mission_inquisition_tomb_world(necron_tomb_worlds); break;
+        //    case INQUISITION_MISSION.tomb_world: mission_inquisition_tomb_world(necron_tomb_worlds); break;
             case INQUISITION_MISSION.tyranid_organism: mission_inquisition_tyranid_organism(tyranid_org_worlds); break;
             case INQUISITION_MISSION.ethereal: mission_inquisition_ethereal(); break;
             case INQUISITION_MISSION.demon_world: mission_inquisition_demon_world(demon_worlds); break;
@@ -189,7 +189,7 @@ function mission_inquisition_tyranid_organism(worlds){
     scr_popup("Inquisition Mission",text,"inquisition",$"tyranid_org|{string(_star.name)}|{string(planet)}|{string(eta+1)}|");
 
 }
-
+/*
 function mission_inquisition_tomb_world(tomb_worlds){
     log_message("RE: Necron Tomb Bombing");
     if (is_array(tomb_worlds)){
@@ -261,7 +261,7 @@ function init_mission_inquisition_tomb_world(){
     add_new_inquis_mission();
     exit;    
 }
-
+*/
 function mission_inquisition_artifact(){
     var text;
     log_message("RE: Artifact Hold");

--- a/scripts/scr_planetary_feature/scr_planetary_feature.gml
+++ b/scripts/scr_planetary_feature/scr_planetary_feature.gml
@@ -60,7 +60,7 @@ function NewPlanetFeature(feature_type, other_data={}) constructor{
 		hiding=true;
 		name = global.name_generator.generate_genestealer_cult_name();		
 		break;
-		case P_features.Necron_Tomb:
+	case P_features.Necron_Tomb:
 		awake = 0;
 		sealed = 0;
 		player_hidden = 1
@@ -110,7 +110,7 @@ function NewPlanetFeature(feature_type, other_data={}) constructor{
 		funds_spent = 0;
 		player_hidden = 0;
 		engineer_score = 0;
-	break;	
+		break;
 	case P_features.Ancient_Ruins:
 		static ruins_explored = scr_ruins_explored;
 		static explore = scr_explore_ruins;


### PR DESCRIPTION
## Purpose and Description
- Version up to "v0.11.05.06";
- Sweeps the necron tomb crash issues under the rug (commenting code out);
- A few flavor text changes.

## Testing done
- Compiled with gamemaker;
- Made it to the game with random chapter;
- Ended turn numerous times, even past a gene-seed tithe once.
- Explored majority of planetary features in sector map. No necron tombs were found;
- Saved and loaded the game.

## Related things and/or additional context
- #40 