### PR TITLE
feat: trait addition

### DIFF
--- a/datafiles/main/version.json
+++ b/datafiles/main/version.json
@@ -1,5 +1,5 @@
 {
-    "build_date": "2026-01-23",
-    "version": "v0.11.05.06",
+    "build_date": "2026-01-25",
+    "version": "v0.11.05.07",
     "commit_hash": "unknown hash"
 }

--- a/objects/obj_controller/Create_0.gml
+++ b/objects/obj_controller/Create_0.gml
@@ -1031,7 +1031,7 @@ known[eFACTION.Tau]=0;
 known[eFACTION.Tyranids]=0;
 known[eFACTION.Chaos]=0;
 known[eFACTION.Heretics]=0;
-known[12]=0;
+known[12]=0; // It should be the Daemons faction
 known[eFACTION.Necrons]=0;
 
 // UI testing
@@ -1128,8 +1128,29 @@ if (instance_exists(obj_ini)){
             obj_controller.disposition[7]+=5;
             obj_controller.disposition[8]+=10;
         }
+        if (scr_has_disadv("Enemy: Imperium")) {
+			// Imperials
+            obj_controller.disposition[2]-=40;
+            faction_status[eFACTION.Imperium]="War";
+            obj_controller.disposition[3]-=40;
+            faction_status[eFACTION.Mechanicus]="War";
+            obj_controller.disposition[4]-=40;
+            faction_status[eFACTION.Inquisition]="War";
+            obj_controller.disposition[5]-=40;
+            faction_status[eFACTION.Ecclesiarchy]="War";
+			// Chaos
+            obj_controller.disposition[10]+=35;
+            faction_status[eFACTION.Chaos]="Antagonism";
+            known[eFACTION.Chaos]=1; // Or, maybe it should be 2?
+            obj_controller.disposition[11]+=35;
+            faction_status[eFACTION.Heretics]="Antagonism";
+			// Should Daemons be included? If so, repeat for faction 12
+        }
         if (scr_has_adv("Enemy: Eldar")) {
             faction_status[eFACTION.Eldar]="War";
+        }
+        if (scr_has_adv("Enemy: Tau")) {
+            faction_status[eFACTION.Tau]="War";
         }
         // Founding Chapter STC Bonuses here
         if (global.chapter_name=="Salamanders"){

--- a/objects/obj_creation/Create_0.gml
+++ b/objects/obj_creation/Create_0.gml
@@ -591,7 +591,7 @@ var all_advantages = [
             name : "Bolter Drilling",
             description : "Bolter drills are sacred to your chapter; all marines have increased attack with Bolter weaponry.",
             value : 40,
-            meta : ["Weapon Specialty"]
+        //    meta : ["Weapon Specialty"]
         },
         {
             name : "Retinue of Renown",
@@ -602,7 +602,7 @@ var all_advantages = [
             name : "Crafters",
             description : "Your chapter views artifacts as sacred; you start with better gear and maintain all equipment with more ease.",
             value : 40,
-            meta : ["Gear Quality"]
+        //    meta : ["Gear Quality"]
         },
         {
             name : "Ancient Armoury",
@@ -614,43 +614,43 @@ var all_advantages = [
             name : "Enemy: Eldar",
             description : "Eldar are particularly hated by your chapter.  When fighting Eldar damage is increased.",
             value : 20,
-            meta : ["Main Enemy"],
+        //    meta : ["Main Enemy"],
         },
         {
             name : "Enemy: Fallen",
             description : "Chaos Marines are particularly hated by your chapter.  When fighting the traitors damage is increased.",
-            value : 20,
-            meta : ["Main Enemy"],
+            value : 20, // Should it be allowed together with "Enemy: Imperium"?
+        //    meta : ["Main Enemy"],
         },
         {
             name : "Enemy: Necrons",
             description : "Necrons are particularly hated by your chapter.  When fighting Necrons damage is increased.",
             value : 20,
-            meta : ["Main Enemy"],
+        //    meta : ["Main Enemy"],
         },  
         {
             name : "Enemy: Orks",
             description : "Orks are particularly hated by your chapter.  When fighting Orks damage is increased.",
             value : 20,
-            meta : ["Main Enemy"]
+        //    meta : ["Main Enemy"]
         },
         {
             name : "Enemy: Tau",
             description : "Tau are particularly hated by your chapter.  When fighting Tau damage is increased.",
             value : 20,
-            meta : ["Main Enemy"],
+        //    meta : ["Main Enemy"],
         },
         {
             name : "Enemy: Tyranids",
             description : "Tyranids are particularly hated by your chapter. A large number of your veterans and marines are tyrannic war veterans and when fighting Tyranids damage is increased.",
             value : 20,
-            meta : ["Main Enemy"],
+        //    meta : ["Main Enemy"],
         },
         {
             name : "Kings of Space",
             description : "Veterans of naval combat, your chapter fleet has bonuses to offense, defence, an additional battle barge, and may always be controlled regardless of whether or not the Chapter Master is present.",
             value : 40,
-            meta : ["Naval"],
+        //    meta : ["Naval"],
         },
         {
             name : "Lightning Warriors",
@@ -730,7 +730,7 @@ var all_advantages = [
             name : "Ryzan Patronage",
             description : "Your chapter has strong ties to the Forgeworld of Ryza as a result your Techmarines are privy to the secrets of their Techpriests enhancing your Plasma and Las weaponry.",
             value : 40,
-            meta : ["Weapon Specialty"] 
+        //    meta : ["Weapon Specialty"] 
         },
         {
             name: "Elite Guard",
@@ -779,6 +779,7 @@ var all_disadvantages = [
         name : "Blood Debt",
         description : "Prevents your Chapter from recruiting new Astartes until enough of your marines, or enemies, have been killed.  Incompatible with Penitent chapter types.",
         value : 50,
+        meta : ["Allegiance"], // It shouldn't be compatible with "Enemy: Imperium" either
     },
     {
         name : "Depleted Gene-seed Stocks",
@@ -793,8 +794,8 @@ var all_disadvantages = [
     }, 
     {
         name : "Never Forgive",
-        description : "In the past traitors broke off from your chapter.  They harbor incriminating secrets or heritical beliefs, and as thus, must be hunted down whenever possible.",
-        value : 20,
+        description : "In the past traitors broke off from your chapter.  They harbor incriminating secrets or heretical beliefs, and as thus, must be hunted down whenever possible.",
+        value : 20, // It is kind of weird with "Enemy: Imperium", might be prudent to add it to ["Allegiance"] meta.
     },
     {
         name : "Shitty Luck",
@@ -844,7 +845,7 @@ var all_disadvantages = [
     },
     {
         name : "Obliterated",
-        description : "A recent string of unfortunate events has left your chapter decimated. You have very little left, will your story continue?",
+        description : "Considering the extreme losses that your chapter took, it should've been disbanded. However, for whatever reason, you are to continue the fight...",
         value : 80,
         meta : ["Status"],
     },
@@ -858,11 +859,11 @@ var all_disadvantages = [
         name : "Enduring Angels",
         description : "The Chapter's journey thus far has been arduous & unforgiving leaving them severely understrength yet not out of the fight. You begin with 5 fewer company's",
         value : 30,
-        meta : ["Status"],
+        meta : ["Status"], // Trait seems a bit pointless when "Sieged" is an option.
     },
     {
         name : "Serpents Delight",
-        description : "Sleeper cells infiltrated your chapter. When they rose up for the decapitation strike,they slew the 5 most experienced company's and many of the HQ staff before being defeated",
+        description : "Your chapter has recently suffered losses among its most experienced troops.",
         value : 50,
         meta : ["Status"],
     },
@@ -884,6 +885,12 @@ var all_disadvantages = [
         value : 20,
         meta : ["Psyker Views","Librarians"],
     },
+        {
+        name : "Enemy: Imperium",
+        description : "For whatever reason, your chapter is considered traitors to the Imperium. You gained contacts to local traitor elements, at least.",
+        value : 40, // 10 for each imperial faction.
+        meta : ["Allegiance"], // Should it be allowed together with "Enemy: Fallen"?
+        },
     {
         name : "Tech Regression: Late Conventional",
         description : "Whether due to brief period of isolation or simple negligence, your forge lacks some facilities. You'll need to spend some techmarine resources to rebuild them.",

--- a/scripts/scr_random_event/scr_random_event.gml
+++ b/scripts/scr_random_event/scr_random_event.gml
@@ -87,7 +87,7 @@ function scr_random_event(execute_now) {
 						EVENT.mutation,
 						EVENT.ship_lost, // Another save-scumming event, mainly due to rarity of player ships
 						//EVENT.chaos_invasion, // Spawns Chaos fleets way too close to player owned worlds with no warning and usually lots of big ships, save-scum galore and encourages fleet-based chapters // TODO LOW INVASION_EVENT // Make them spawn way farther with more warning, make them have a different goal or remove this event entirely
-						EVENT.necron_awaken, // Inquisitor check for this is inverted
+						//EVENT.necron_awaken, // Inquisitor check for this is inverted
 						EVENT.fallen, // Event mission cannot be completed and never expires // TODO LOW FALLEN_EVENT // fix
 					];
 				}


### PR DESCRIPTION
## Purpose and Description
- Adds "Enemy: Imperium" trait, which allows player to play as renegade from the game start;
- Comments out some mutual exclusivity of traits, allowing more varied combinations;
- Necron leftovers commented out;
- "Enemy: Tau" now makes player start at war with them;
- "v0.11.05.07" is the new version.

## Testing done
- Compiled in Gamemaker;
- Made it to the game with custom chapter, with the "Enemy: Imperium" trait;
- Ended several turns;
- Spawned chaos fleet with debug commands;
- Saved and loaded the game.

## Related things and/or additional context
Addresses #42 
Based on testing results, it is still rough around the edges - such as descriptions still requiring more tweaks.