### PR TITLE
feat: disable inspections

### DIFF
--- a/datafiles/main/version.json
+++ b/datafiles/main/version.json
@@ -1,5 +1,5 @@
 {
-    "build_date": "2026-01-25",
-    "version": "v0.11.05.07",
+    "build_date": "2026-01-30",
+    "version": "v0.11.05.08",
     "commit_hash": "unknown hash"
 }

--- a/objects/obj_controller/Alarm_5.gml
+++ b/objects/obj_controller/Alarm_5.gml
@@ -115,16 +115,22 @@ if (turn=240) and (global.chapter_name="Lamenters"){
     scr_popup("Geneseed Mutation","Your Chapter has begun to have visions and nightmares of Sanguinius' fall.  The less mentally disciplined of your battle-brothers no longer are able to sleep soundly, waking from sleep in a screaming, frothing rage.  It appears the Black Rage has returned.","black_rage","");    
 }
 */
-// ** Battlefield Loot **
+// ** Loot from Scavengers Trait **
 if (scr_has_adv("Tech-Scavengers")){
     var lroll1,lroll2,loot="";
     lroll1=roll_dice_chapter(1, 100, "low");
     lroll2=roll_dice_chapter(1, 100, "low");
     if (lroll1<=5){
-        loot=choose("Chainsword","Bolt Pistol","Combat Knife","Narthecium");
-        if (lroll2<=80) then loot=choose("Power Sword","Storm Bolter");
-        if (lroll2<=60) then loot=choose("Plasma Pistol","Chainfist","Lascannon","Heavy Bolter","Assault Cannon","Bike");
-        if (lroll2<=30) then loot=choose("Artificer Armour","Plasma Gun","Chainfist","Rosarius","Psychic Hood");
+		// The weakest rolls should be mostly basic weaponry, fit for scout marines or hirelings
+        loot=choose("Combat Knife","Hellgun","Laspistol","Scout Armour");
+		// The (sub)standard kit of a space marine
+        if (lroll2<=80) then loot=choose("Chainsword","Bolt Pistol","Bolter","Sniper Rifle","Heavy Weapons Pack","MK5 Heresy");
+		// Better equipped marines
+		// TODO - refine the list further, with greater variation of power weapons, and combi tag weapons
+        if (lroll2<=60) then loot=choose("Power Sword","Power Axe","Chainfist","Plasma Pistol","Lascannon","Heavy Bolter","Assault Cannon","Bike","MK7 Aquila");
+		// Specialist-tier loot
+        if (lroll2<=30) then loot=choose("Crozius Arcanum","Storm Bolter","Plasma Gun","Rosarius","Psychic Hood","Narthecium","Servo-arm","MK6 Corvus");
+		// And, ultimately, hi-end loot
         if (lroll2<=10) then loot=choose("Terminator Armour","Artificer Armour","Dreadnought","Plasma Gun","Power Fist","Thunder Hammer","Iron Halo");
         var tix="A "+string(loot)+" has been gifted to the Chapter.";
         tix=string_replace(tix,"A A","An A");
@@ -255,7 +261,10 @@ for (var c = 0; c < 11; c++){
             penit_co[p]=c;
             penit_id[p]=e;
             penitorium+=1;
-            unit.alter_loyalty(-1);
+			// Loyalty of unit changes needs some considerations
+			// Putting a unit in penitorium should perhaps subtract a point of loyalty, once
+			// But loss per turn should be reconsidered
+        //    unit.alter_loyalty(-1);
             if (unit.corruption<90) and (unit.corruption>0){
                 var heresy_old=0,heresy_new=0;
                 heresy_old=round((unit.corruption*unit.corruption)/50)-0.5;
@@ -419,14 +428,18 @@ if (loyalty_counter==0) then scr_loyalty("Undevout","+");
 if (marines>=1050) then scr_loyalty("Non-Codex Size","+");
 
 var last_inquisitor_inspection=0;
+/*
 if (obj_ini.fleet_type=ePlayerBase.home_world) then last_inquisitor_inspection=last_world_inspection;
 if (obj_ini.fleet_type != ePlayerBase.home_world) then last_inquisitor_inspection=last_fleet_inspection;
+*/
 
 var inspec=false;
+/*
 if (loyalty>=85) and ((last_inquisitor_inspection+59)<turn) then inspec=true;
 if (loyalty>=70) and (loyalty<85) and ((last_inquisitor_inspection+47)<turn) then inspec=true;
 if (loyalty>=50) and (loyalty<70) and ((last_inquisitor_inspection+35)<turn) then inspec=true;
 if (loyalty<50) and ((last_inquisitor_inspection+11+choose(1,2,3,4))<turn) then inspec=true;
+*/
 
 if (obj_ini.fleet_type != ePlayerBase.home_world){
     if (instance_number(obj_p_fleet)==1) and (obj_ini.fleet_type = ePlayerBase.home_world){// Might be crusading, right?

--- a/objects/obj_controller/Create_0.gml
+++ b/objects/obj_controller/Create_0.gml
@@ -1023,7 +1023,8 @@ known[0]=2;
 known[eFACTION.Player]=999;
 known[eFACTION.Imperium]=1; // TODO: tweak these with certain traits in mind
 known[eFACTION.Mechanicus]=1;
-known[eFACTION.Inquisition]=0;
+// Making 1, otherwise player won't be given missions/quests from inquisition, because inspections are disabled
+known[eFACTION.Inquisition]=1;
 known[eFACTION.Ecclesiarchy]=0;
 known[eFACTION.Eldar]=0;
 known[eFACTION.Ork]=0;
@@ -1122,6 +1123,11 @@ other1="";
 if (instance_exists(obj_ini)){
     // General setup
     if (global.load==-1){
+        if (scr_has_disadv("Suspicious")) {
+			// I decided to use "Suspicious" instead of creating a separate "Antagonism: Imperium".
+			// If player wants no quests from inquisition, this trait should be selected.
+            known[eFACTION.Inquisition]=0;
+            }
         // Tolerant trait
         if (scr_has_disadv("Tolerant")) {
             obj_controller.disposition[6]+=5;
@@ -1130,18 +1136,30 @@ if (instance_exists(obj_ini)){
         }
         if (scr_has_disadv("Enemy: Imperium")) {
 			// Imperials
+			// Might need to set "known" to 2 instead of 1. Either is needed to reveal them in diplomacy screen
+			// Normally, when player becomes renegade, imperials faction leaders generally contact the player,
+			// to inform of the changed diplomatic situation - at least if their disposition goes into negative values,
+			// and contacting generally means known=2
             obj_controller.disposition[2]-=40;
             faction_status[eFACTION.Imperium]="War";
+            known[eFACTION.Imperium]=2;
             obj_controller.disposition[3]-=40;
             faction_status[eFACTION.Mechanicus]="War";
+            known[eFACTION.Mechanicus]=2;
             obj_controller.disposition[4]-=40;
             faction_status[eFACTION.Inquisition]="War";
+            known[eFACTION.Inquisition]=2;
             obj_controller.disposition[5]-=40;
             faction_status[eFACTION.Ecclesiarchy]="War";
+            known[eFACTION.Ecclesiarchy]=2;
 			// Chaos
+			// Testing has shown that at -35 disposition, the color is red, which could deceive the player about the relationship status
+			// red ideally should stand for "war", yellow/orange should be for "antagonism".
             obj_controller.disposition[10]+=35;
             faction_status[eFACTION.Chaos]="Antagonism";
-            known[eFACTION.Chaos]=1; // Or, maybe it should be 2?
+			// With 2, it means player has had an audience with the faction leader
+			// Which in turn makes the situation the same as player becoming renegade via the usual ways
+            known[eFACTION.Chaos]=2;
             obj_controller.disposition[11]+=35;
             faction_status[eFACTION.Heretics]="Antagonism";
 			// Should Daemons be included? If so, repeat for faction 12

--- a/objects/obj_creation/Create_0.gml
+++ b/objects/obj_creation/Create_0.gml
@@ -591,7 +591,6 @@ var all_advantages = [
             name : "Bolter Drilling",
             description : "Bolter drills are sacred to your chapter; all marines have increased attack with Bolter weaponry.",
             value : 40,
-        //    meta : ["Weapon Specialty"]
         },
         {
             name : "Retinue of Renown",
@@ -602,7 +601,6 @@ var all_advantages = [
             name : "Crafters",
             description : "Your chapter views artifacts as sacred; you start with better gear and maintain all equipment with more ease.",
             value : 40,
-        //    meta : ["Gear Quality"]
         },
         {
             name : "Ancient Armoury",
@@ -614,43 +612,42 @@ var all_advantages = [
             name : "Enemy: Eldar",
             description : "Eldar are particularly hated by your chapter.  When fighting Eldar damage is increased.",
             value : 20,
-        //    meta : ["Main Enemy"],
         },
         {
             name : "Enemy: Fallen",
             description : "Chaos Marines are particularly hated by your chapter.  When fighting the traitors damage is increased.",
-            value : 20, // Should it be allowed together with "Enemy: Imperium"?
-        //    meta : ["Main Enemy"],
+            value : 20,
+		// Should it be allowed together with "Enemy: Imperium"?
+		// Some may argue that this should be incompatible, considering similar traits make the player at war with respective factions.
+		// But on the other hand, chaos forces are varied, so it would not be out of place for chaos-aligned force capable against other chaos forces,
+		// while still maintaining... "Cold war" ("Antagonism") state with each other.
+		// For any contributor wanting to change this, you may uncomment the line below.
+        //    meta : ["Allegiance"],
         },
         {
             name : "Enemy: Necrons",
             description : "Necrons are particularly hated by your chapter.  When fighting Necrons damage is increased.",
             value : 20,
-        //    meta : ["Main Enemy"],
         },  
         {
             name : "Enemy: Orks",
             description : "Orks are particularly hated by your chapter.  When fighting Orks damage is increased.",
             value : 20,
-        //    meta : ["Main Enemy"]
         },
         {
             name : "Enemy: Tau",
             description : "Tau are particularly hated by your chapter.  When fighting Tau damage is increased.",
             value : 20,
-        //    meta : ["Main Enemy"],
         },
         {
             name : "Enemy: Tyranids",
             description : "Tyranids are particularly hated by your chapter. A large number of your veterans and marines are tyrannic war veterans and when fighting Tyranids damage is increased.",
             value : 20,
-        //    meta : ["Main Enemy"],
         },
         {
             name : "Kings of Space",
             description : "Veterans of naval combat, your chapter fleet has bonuses to offense, defence, an additional battle barge, and may always be controlled regardless of whether or not the Chapter Master is present.",
             value : 40,
-        //    meta : ["Naval"],
         },
         {
             name : "Lightning Warriors",
@@ -724,25 +721,24 @@ var all_advantages = [
             name : "Medicae Primacy",
             description : "Your chapter reveres its Apothecarion above all of it's specialist; You start with more Apothecaries.",
             value : 20,
-            meta : ["Apothecaries"]
+            meta : ["Apothecaries"],
         },
         {
             name : "Ryzan Patronage",
             description : "Your chapter has strong ties to the Forgeworld of Ryza as a result your Techmarines are privy to the secrets of their Techpriests enhancing your Plasma and Las weaponry.",
             value : 40,
-        //    meta : ["Weapon Specialty"] 
         },
         {
             name: "Elite Guard",
             description: "Your chapter is an elite fighting force comprised almost exclusively of Veterans. All Tactical Marines are replaced by Veterans.",
             value: 150,
-            meta: ["Specialists"]
+            meta: ["Specialists"],
         },
         {
             name : "Great Luck",
             description: "This is actually really helpful and beneficial for your chapter. Trust me.",
             value: 20,
-            meta: ["Luck"]
+            meta: ["Luck"],
         },                                                                                                                                                           
     ]
 
@@ -795,13 +791,17 @@ var all_disadvantages = [
     {
         name : "Never Forgive",
         description : "In the past traitors broke off from your chapter.  They harbor incriminating secrets or heretical beliefs, and as thus, must be hunted down whenever possible.",
-        value : 20, // It is kind of weird with "Enemy: Imperium", might be prudent to add it to ["Allegiance"] meta.
+        value : 20,
+		// It is kind of weird with "Enemy: Imperium", might be prudent to add it to ["Allegiance"] meta.
+		// But on the other hand, might as well let the player experiment, I suppose?
+		// Uncomment the line below, if you believe it should be incompatible.
+        // meta : ["Allegiance"],
     },
     {
         name : "Shitty Luck",
         description: "This is actually really bad for your chapter. Trust me.",
         value: 20,
-        meta: ["Luck"]
+        meta: ["Luck"],
     },
     {
         name : "Sieged",
@@ -817,8 +817,10 @@ var all_disadvantages = [
     },
     {
         name : "Suspicious",
-        description : "Some of your chapter's past actions or current practices make the inquisition suspicious.  Their disposition is lowered.",
-        value : 10,
+        description : "Your chapter has consistently evaded contact of inquisition. While you won't be able to negotiate with them, you won't get missions either.",
+		// Value of 0, as it has some advantages - no annoying inquisition missions - while drawbacks are fairly minor,
+		// such as not being able to trade with inquisition
+        value : 0,
         meta : ["Imperium Trust"],
     },
     {
@@ -853,7 +855,7 @@ var all_disadvantages = [
         name : "Poor Equipment",
         description : "Whether due to being cut off from forge worlds or bad luck, your chapter no longer has enough high quality gear to go around. Your elite troops will have to make do with standard armour.",
         value: 10,
-        meta : ["Gear Quality"]
+        meta : ["Gear Quality"],
     },
     {
         name : "Enduring Angels",
@@ -889,7 +891,7 @@ var all_disadvantages = [
         name : "Enemy: Imperium",
         description : "For whatever reason, your chapter is considered traitors to the Imperium. You gained contacts to local traitor elements, at least.",
         value : 40, // 10 for each imperial faction.
-        meta : ["Allegiance"], // Should it be allowed together with "Enemy: Fallen"?
+        meta : ["Allegiance"],
         },
     {
         name : "Tech Regression: Late Conventional",

--- a/scripts/scr_PlanetData/scr_PlanetData.gml
+++ b/scripts/scr_PlanetData/scr_PlanetData.gml
@@ -165,7 +165,8 @@ function PlanetData(planet, system) constructor{
     	planet_forces[1] = player_forces;
 
 	    planet_forces[2] =	guardsmen;
-
+	//    planet_forces[3] =	system.p_mechanicus[planet];
+	//    planet_forces[4] =	system.p_inquisition[planet];
 	    planet_forces[5] =	system.p_sisters[planet];
 	    planet_forces[6] =	system.p_eldar[planet];
 	    planet_forces[7] =	system.p_orks[planet];
@@ -212,6 +213,12 @@ function PlanetData(planet, system) constructor{
             case eFACTION.Ecclesiarchy:
                 system.p_sisters[planet] = _new_val;
                 break;                                  
+			// case eFACTION.Mechanicus:
+			//	system.p_mechanicus[planet] = _new_val;
+			//	break;
+			// case eFACTION.Inquisition:
+			//	system.p_inquisition[planet] = _new_val;
+			//	break;
         }
 
         return _new_val
@@ -956,6 +963,17 @@ function PlanetData(planet, system) constructor{
             if (current_owner=8){
                 draw_text(xx+480,yy+y7,$"Gue'Vesa Force:  {temp4}");
             }
+			// if (current_owner=10){
+            //    draw_text(xx+480,yy+y7,$"Traitor Guard:  {temp4}");
+            //}
+			// if (current_owner=11){
+            //    draw_text(xx+480,yy+y7,$"Traitor Militia:  {temp4}");
+            //}
+			// Eldar generally relocate the humans elsewhere, if lore-versed folks are to be believed
+			// Still, if anyone prefers for eldar to try recruiting humans, you can try the option below.
+			// if (current_owner=6){
+            //    draw_text(xx+480,yy+y7,$"Traitor Militia:  {temp4}");
+            //}
         }
         
         var temp5="";
@@ -1039,6 +1057,7 @@ function PlanetData(planet, system) constructor{
         
         
         var presence_text = "";
+		// TODO add Mechanicus and Inquisition forces eventually
         var faction_names = ["Adeptas", "Orks", "Tau", "Tyranids", "Chaos", "Traitors", "Daemons", "Necrons"];
         var faction_ids = ["p_sisters", "p_orks", "p_tau", "p_tyranids", "p_traitors", "p_chaos", "p_demons", "p_necrons"];
         var blurbs = ["Squad+", "Squads++", "Demi-Company", "Company", "Company+", "Companies++", "Chapter/2", "Chapter"];

--- a/scripts/scr_enemy_ai_a/scr_enemy_ai_a.gml
+++ b/scripts/scr_enemy_ai_a/scr_enemy_ai_a.gml
@@ -38,9 +38,11 @@ function scr_enemy_ai_a() {
 	}
 
 	// checking for inquisition dead world inspections here
+	/*
 	if (present_fleet[eFACTION.Player]>=0 && !present_fleet[eFACTION.Inquisition]){
 		inquisitor_inspect_base();
 	}
+	*/
 
 	var stop;
 	var rand=0;

--- a/scripts/scr_inquisition_fleet_functions/scr_inquisition_fleet_functions.gml
+++ b/scripts/scr_inquisition_fleet_functions/scr_inquisition_fleet_functions.gml
@@ -25,7 +25,7 @@ function hunt_player_serfs(planet, system){
     });
 }
 
-
+/*
 function radical_inquisitor_mission_ship_arrival(){
 
     //TODO make a centralised player_fleet present method
@@ -69,7 +69,7 @@ function radical_inquisitor_mission_ship_arrival(){
     //instance_destroy();
     exit;
 }
-/*
+
 function inquisition_fleet_inspection_chase(){
 	var good=0,acty="";
 	var reset = !instance_exists(target);
@@ -146,14 +146,12 @@ function inquisition_fleet_inspection_chase(){
         
             exit;
 		}
-    }
+    
 }
-*/
 // TODO maybe have the inquisitor or his team as an actual entity that goes around and can die, which gives the player time to fix stuff 
 // either kill the inquisitor or he dies in combat
 
 // Sets up an inquisitor ship to do an inspection on the HomeWorld
-/*
 function new_inquisitor_inspection(){
 	var target_system = "none";
 	var new_inquis_fleet;
@@ -228,8 +226,7 @@ function new_inquisitor_inspection(){
         instance_activate_object(obj_star);
     }
 }
-*/
-/*
+
 function inquisitor_ship_approaches(){
     //TODO figure out the meaning of this line
     if ((string_count("eet",trade_goods)!=0) and (string_count("_her",trade_goods)!=0)) then exit;
@@ -265,10 +262,10 @@ function inquisitor_ship_approaches(){
         scr_popup("Inquisition Inspection", inquis_string, "");
     }
 }
-*/
+
 
 ///@Mixin obj_star
-/*
+
 function inquisitor_inspect_base(){
     var chapter_asset_discovery,yep=0,stop=false;
    
@@ -288,7 +285,7 @@ function inquisitor_inspect_base(){
                 p_owner[cur_planet]=1;
             }
             if (p_type[cur_planet]=="Dead") and (array_length(p_upgrades[cur_planet])>0){
-                if (planet_feature_bool(p_feature[cur_planet], [P_features.Secret_Base,P_features.Arsenal,P_features.Gene_Vault])==0) /*and (string_count(".0|",p_upgrades[cur_planet])>0)*/{
+                if (planet_feature_bool(p_feature[cur_planet], [P_features.Secret_Base,P_features.Arsenal,P_features.Gene_Vault])==0) /*and (string_count(".0|",p_upgrades[cur_planet])>0)*//*{
                     yep=cur_planet;
                 }
             }

--- a/scripts/scr_inquisition_fleet_functions/scr_inquisition_fleet_functions.gml
+++ b/scripts/scr_inquisition_fleet_functions/scr_inquisition_fleet_functions.gml
@@ -1,3 +1,4 @@
+/*
 function base_inquis_fleet(){
 	owner=eFACTION.Inquisition;
     frigate_number=1;
@@ -12,6 +13,7 @@ function base_inquis_fleet(){
         inquisitor = inquis_choice
     }
 }
+*/
 
 
 function hunt_player_serfs(planet, system){
@@ -67,6 +69,7 @@ function radical_inquisitor_mission_ship_arrival(){
     //instance_destroy();
     exit;
 }
+/*
 function inquisition_fleet_inspection_chase(){
 	var good=0,acty="";
 	var reset = !instance_exists(target);
@@ -145,10 +148,12 @@ function inquisition_fleet_inspection_chase(){
 		}
     }
 }
+*/
 // TODO maybe have the inquisitor or his team as an actual entity that goes around and can die, which gives the player time to fix stuff 
 // either kill the inquisitor or he dies in combat
 
 // Sets up an inquisitor ship to do an inspection on the HomeWorld
+/*
 function new_inquisitor_inspection(){
 	var target_system = "none";
 	var new_inquis_fleet;
@@ -223,7 +228,8 @@ function new_inquisitor_inspection(){
         instance_activate_object(obj_star);
     }
 }
-
+*/
+/*
 function inquisitor_ship_approaches(){
     //TODO figure out the meaning of this line
     if ((string_count("eet",trade_goods)!=0) and (string_count("_her",trade_goods)!=0)) then exit;
@@ -259,9 +265,10 @@ function inquisitor_ship_approaches(){
         scr_popup("Inquisition Inspection", inquis_string, "");
     }
 }
-
+*/
 
 ///@Mixin obj_star
+/*
 function inquisitor_inspect_base(){
     var chapter_asset_discovery,yep=0,stop=false;
    
@@ -325,4 +332,4 @@ function inquisitor_inspect_base(){
     }
     
 }
-
+*/

--- a/scripts/scr_inquisition_mission/scr_inquisition_mission.gml
+++ b/scripts/scr_inquisition_mission/scr_inquisition_mission.gml
@@ -831,11 +831,11 @@ function necron_tomb_mission_sequence(){
             text = "The energy readings are much stronger, now that your marines are deep inside the tunnels.  What was once cramped is now luxuriously large, the tunnel ceiling far overhead decorated by stalactites.";
         } else if (pop_data.mission_stage == 3) {
             image = "necron_tunnels_3";
-            text = "After several hours of descent the entrance to the Necron Tomb finally looms ahead- dancing, sickly green light shining free.  Your marine confirms that the Plasma Bomb is ready.";
+            text = "After several hours of descent, the entrance to the Necron Tomb looms ahead - green light clearly visible.  Your marine confirms that the Plasma Bomb is ready.";
         } else if (pop_data.mission_stage >= 4) {
             image = "";
             title = "Inquisition Mission Completed";
-            text = "Your marines finally enter the deepest catacombs of the Necron Tomb.  There they place the Plasma Bomb and arm it.  All around are signs of increasing Necron activity.  With half an hour set, your men escape back to the surface.  There is a brief rumble as the charge goes off, your mission a success.";
+            text = "Your marines finally enter the deepest catacombs of the Necron Tomb.  There they place the Plasma Bomb and arm it.  All around are signs of increasing Necron activity.  Within half an hour, your men escape back to the surface.  A brief quake is noted as the charge goes off.  Mission is a success.";
             reset_popup_options();
 
             alter_disposition(eFACTION.Inquisition, obj_controller.demanding ? choose(0, 0, 1) : 1);

--- a/scripts/scr_inquisition_mission/scr_inquisition_mission.gml
+++ b/scripts/scr_inquisition_mission/scr_inquisition_mission.gml
@@ -110,7 +110,7 @@ function scr_inquisition_mission(event, forced_mission = -1){
         }
         switch (chosen_mission){
             case INQUISITION_MISSION.purge: mission_inquistion_purge(); break;
-            case INQUISITION_MISSION.inquisitor: mission_inquistion_hunt_inquisitor(); break;
+        //    case INQUISITION_MISSION.inquisitor: mission_inquistion_hunt_inquisitor(); break;
             case INQUISITION_MISSION.spyrer: mission_inquistion_spyrer(); break;
             case INQUISITION_MISSION.artifact: mission_inquisition_artifact(); break;
         //    case INQUISITION_MISSION.tomb_world: mission_inquisition_tomb_world(necron_tomb_worlds); break;

--- a/scripts/scr_weapon/scr_weapon.gml
+++ b/scripts/scr_weapon/scr_weapon.gml
@@ -741,7 +741,7 @@ global.weapons = {
         "abbreviation": "PwrAxe",
         "attack": {
             "standard": 575,
-            "master_crafted": 600,
+            "master_crafted": 625,
             "artifact": 675
         },
         "melee_mod": {
@@ -764,7 +764,7 @@ global.weapons = {
         "attack": {
             "standard": 550,
             "master_crafted": 600,
-            "artifact": 675
+            "artifact": 650
         },
         "melee_mod": {
             "standard": 0,
@@ -2362,11 +2362,11 @@ global.weapons = {
     },
     "Ranger Long Rifle":{
         "abbreviation": "RangeLoRife",
-        "description":"Advanced and accurate rifles from a non-imperial entity.",
+        "description":"Advanced and accurate rifle, seemingly eldar origin.",
         "attack": {
           "standard": 500,
-          "master_crafted": 620,
-          "artifact": 740
+          "master_crafted": 625,
+          "artifact": 750
         },
         "melee_hands": 1,
         "ranged_hands": 1.75,


### PR DESCRIPTION
## Purpose and Description
Inquisition with it's inspections - while lore-accurate, showing questionable capabilities in helping maintain imperial control of the sector, yet capable of getting in the way of player - is generally a detriment to the gameplay.
In this case, gameplay takes a higher priority, than lore accuracy.
Also addresses the questionable point of hidden facilities - them being eventually discovered with inspections - with inspections removed, player can construct facilities on dead worlds without the risk of inquisition's discovery and subsequent disposition damage and even becoming enemy (renegades) of the imperium.

- "0.11.05.08" is the new version;
- Loot table from "scavengers" trait is modified;
- Marines put into penitorium don't lose loyalty;
- Inquisition inspections are disabled;
- Inquisition is made known by default on game start - so missions/quests can be received;
- "Suspicious" trait is modified, it now makes inquisition unknown;
- "Enemy: Imperium" is modified;
- Comments changed, elaborated in some places, removed in others;
- "Rogue Inquisitor" mission disabled.

## Testing done
- Running in Gamemaker;
- Making to the game with custom chapter, with "Suspicious" disadvantage;
- Press end turn ~121 times;
- Save and load, and end a turn.

## Related things and/or additional context
- Indirectly touches upon issue #33 , with "Suspicious" giving a way to bypass missions from inquisition entirely.